### PR TITLE
docs(angular/copilot-instructions.md): prefer .prettierc

### DIFF
--- a/rules-copilot-instructions/angular-typescript/copilot-instructions.md
+++ b/rules-copilot-instructions/angular-typescript/copilot-instructions.md
@@ -11,7 +11,6 @@
 - Prefer using the forNext function from libs/smart-ngrx/src/common/for-next.function.ts over for/forEach/for-of.
 - Obey .eslintrc.json, .prettierrc, .htmlhintrc, and .editorconfig rules.
 - Functions/methods: max 4 parameters, max 50 executable lines.
-- Lines: max 80 characters.
 - When refactoring, keep jsdoc comments intact.
 - Be concise and minimize extraneous prose.
 - If you don't know the answer, say so instead of guessing.


### PR DESCRIPTION
Remove the max 80 characters to favorise the .prettierrc file content

## Note
In case this issue is accepted: https://github.com/Vishavjeet6/awesome-copilot-instructions/issues/1